### PR TITLE
change return var to match function return code and output

### DIFF
--- a/run_ok.sh
+++ b/run_ok.sh
@@ -84,7 +84,7 @@ run_ok () {
                 else
 			printf "Failed with error: ${res}\n" >> ${RUN_LOG}
                         env printf "${REDBG}[  ${BALLOT_X}  ]${NORMAL}\n"
-                        return $?
+                        return $res
                 fi
         else
                 if [ $res -eq 0 ]; then
@@ -94,7 +94,7 @@ run_ok () {
                 else
 			printf "Failed with error: ${res}\n" >> ${RUN_LOG}
                         env printf "${REDBG}[ERROR]${NORMAL}\n"
-                        return $?
+                        return $res
                 fi
         fi
 }


### PR DESCRIPTION
The run_ok function always returned 0 even if the function passed as an argument failed. I modified the return variable so that it captures that of the passed function and forwards it as the output of run_ok.